### PR TITLE
Add the KUDO operator for Cassandra

### DIFF
--- a/operators/cassandra.yaml
+++ b/operators/cassandra.yaml
@@ -1,0 +1,17 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Cassandra
+git-sources:
+- name: kudo-cassandra-operator
+  url: https://github.com/mesosphere/kudo-cassandra-operator.git
+versions:
+- version: "3.11.6-1.0.0"
+  git:
+    source: kudo-cassandra-operator
+    directory: operator
+    tag: v3.11.6-1.0.0
+- version: "3.11.5-0.1.2"
+  git:
+    source: kudo-cassandra-operator
+    directory: operator
+    tag: v3.11.5-0.1.2


### PR DESCRIPTION
This is adding tagged versions of the Cassandra operator hosted at github.com/mesosphere/kudo-cassandra-operator.