### PR TITLE
Add operator packages from 'kudobuilder/operators' to the index

### DIFF
--- a/operators/confluent-rest-proxy.yaml
+++ b/operators/confluent-rest-proxy.yaml
@@ -1,0 +1,17 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Confluent Rest Proxy
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "5.3.2-0.3.0"
+  git:
+    source: operators
+    directory: repository/confluent-rest-proxy/operator
+    sha: 3919e5231c80911cd8ca352cfddba11685953fdb
+- version: "5.3.2-0.2.1"
+  git:
+    source: operators
+    directory: repository/confluent-rest-proxy/operator
+    sha: 8c34d63ff0c28bb9358cb81eea967c30bad4f56c

--- a/operators/confluent-schema-registry.yaml
+++ b/operators/confluent-schema-registry.yaml
@@ -1,0 +1,17 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Confluent Schema Registry
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "5.3.2-0.3.0"
+  git:
+    source: operators
+    directory: repository/confluent-schema-registry/operator
+    sha: 89a1fd281d41e68a22140b4f951397d427889812
+- version: "5.3.2-0.2.1"
+  git:
+    source: operators
+    directory: repository/confluent-schema-registry/operator
+    sha: 55c4e66f77a8a43798276cb43aa844e65c30d72e

--- a/operators/cowsay.yaml
+++ b/operators/cowsay.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Cowsay
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "0.2.0"
+  git:
+    source: operators
+    directory: repository/cowsay/operator
+    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/elastic.yaml
+++ b/operators/elastic.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Elasticsearch
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "7.0.0-0.2.1"
+  git:
+    source: operators
+    directory: repository/elastic/operator
+    sha: 10c82d668a1a63af4eb887857bd0c40dc4881a99

--- a/operators/first-operator.yaml
+++ b/operators/first-operator.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: First Operator
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "0.2.0"
+  git:
+    source: operators
+    directory: repository/first-operator/operator
+    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/flink.yaml
+++ b/operators/flink.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Flink
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "1.7.2-0.2.1"
+  git:
+    source: operators
+    directory: repository/flink/operator
+    sha: 258f17b0a4971460b6a44bbfdfa58e5721486f3a

--- a/operators/kafka.yaml
+++ b/operators/kafka.yaml
@@ -1,0 +1,27 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Kafka
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "2.5.0-1.3.2"
+  git:
+    source: operators
+    directory: repository/kafka/operator
+    sha: e2354fd0ec4cd23144bf5cc15dc613d45d650748
+- version: "2.5.0-1.3.1"
+  git:
+    source: operators
+    directory: repository/kafka/operator
+    sha: b95e9f9aa149592d402f50ee38148b380baf0602
+- version: "2.5.0-1.3.0"
+  git:
+    source: operators
+    directory: repository/kafka/operator
+    sha: 284b6b2aae0f7952a1cc22854483c479ef569e28
+- version: "2.4.1-1.2.1"
+  git:
+    source: operators
+    directory: repository/kafka/operator
+    sha: 92799adea05cbcee9d409cb6a0ae8359887634fa

--- a/operators/mysql.yaml
+++ b/operators/mysql.yaml
@@ -1,0 +1,17 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: MySQL
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "5.7-0.3.0"
+  git:
+    source: operators
+    directory: repository/mysql/operator
+    sha: 8a2e41484513397be353bc5db10e8abc685bc975
+- version: "5.7-0.2.0"
+  git:
+    source: operators
+    directory: repository/mysql/operator
+    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/rabbitmq.yaml
+++ b/operators/rabbitmq.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: RabbitMQ
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "3.8.0-0.1.0"
+  git:
+    source: operators
+    directory: repository/rabbitmq/operator
+    sha: a0a79c9615f139472fc23d4dca0d69dccdb7665c

--- a/operators/redis.yaml
+++ b/operators/redis.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Redis
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "5.0.1-0.2.0"
+  git:
+    source: operators
+    directory: repository/redis/operator
+    sha: 75f64ec77a5d000d801d70885490516a2db15cc6

--- a/operators/spark.yaml
+++ b/operators/spark.yaml
@@ -1,0 +1,27 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Spark
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "2.4.5-1.0.1"
+  git:
+    source: operators
+    directory: repository/spark/operator
+    sha: d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3
+- version: "2.4.5-1.0.0"
+  git:
+    source: operators
+    directory: repository/spark/operator
+    sha: 1db171b3597ba8de91637df6e94edadea4d97d52
+- version: "2.4.5-0.2.0"
+  git:
+    source: operators
+    directory: repository/spark/operator
+    sha: a60cb076107199935bca5e58bae79b2aaade6fb9
+- version: "2.4.4-0.2.0"
+  git:
+    source: operators
+    directory: repository/spark/operator
+    sha: c39b33f09198e5db89b5366155b4e82c397c6269

--- a/operators/zookeeper.yaml
+++ b/operators/zookeeper.yaml
@@ -1,0 +1,12 @@
+apiVersion: index.kudo.dev/v1alpha1
+kind: Operator
+name: Zookeeper
+git-sources:
+- name: operators
+  url: https://github.com/kudobuilder/operators.git
+versions:
+- version: "3.4.14-0.3.0"
+  git:
+    source: operators
+    directory: repository/zookeeper/operator
+    sha: b9036ebc6291b99ff8c10b4947b6e5cf3a159399


### PR DESCRIPTION
All versions supported by KUDO >=0.10 are added by providing SHAs of the respective versions in the `operators` Git repo.