### PR TITLE
Change operators to updated API

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -48,7 +48,7 @@ jobs:
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
             docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
-            update --repository /var/run/repo \
+            update --repository /var/run/repo/index-test \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM HEAD~ | grep operators/ | sed 's/^/\/var\/run\//')
 
@@ -60,4 +60,4 @@ jobs:
           docker run --rm --volumes-from gcloud-cli \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             google/cloud-sdk:slim \
-            gsutil -m rsync -c /var/run/repo gs://kudo-repo/index-test
+            gsutil -m rsync -c /var/run/repo/index-test gs://kudo-repo/index-test

--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           docker run --rm \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
-            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.2.1 \
+            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
             update --repository /var/run/repo \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM HEAD~ | grep operators/ | sed 's/^/\/var\/run\//')

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           docker run --rm \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
-            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.2.1 \
+            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
             update --repository /var/run/repo \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} | grep operators/ | sed 's/^/\/var\/run\//')

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -48,6 +48,6 @@ jobs:
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
             docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
-            update --repository /var/run/repo \
+            update --repository /var/run/repo/index-test \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} | grep operators/ | sed 's/^/\/var\/run\//')

--- a/operators/cassandra.yaml
+++ b/operators/cassandra.yaml
@@ -2,18 +2,18 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Cassandra
 gitSources:
-- name: kudo-cassandra-operator
-  url: https://github.com/mesosphere/kudo-cassandra-operator.git
+  - name: kudo-cassandra-operator
+    url: https://github.com/mesosphere/kudo-cassandra-operator.git
 versions:
-- appVersion: "3.11.6"
-  operatorVersion: "1.0.0"
-  git:
-    source: kudo-cassandra-operator
-    directory: operator
-    tag: v3.11.6-1.0.0
-- appVersion: "3.11.5"
-  operatorVersion: "0.1.2"
-  git:
-    source: kudo-cassandra-operator
-    directory: operator
-    tag: v3.11.5-0.1.2
+  - appVersion: "3.11.6"
+    operatorVersion: "1.0.0"
+    git:
+      source: kudo-cassandra-operator
+      directory: operator
+      tag: v3.11.6-1.0.0
+  - appVersion: "3.11.5"
+    operatorVersion: "0.1.2"
+    git:
+      source: kudo-cassandra-operator
+      directory: operator
+      tag: v3.11.5-0.1.2

--- a/operators/cassandra.yaml
+++ b/operators/cassandra.yaml
@@ -1,16 +1,18 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Cassandra
-git-sources:
+gitSources:
 - name: kudo-cassandra-operator
   url: https://github.com/mesosphere/kudo-cassandra-operator.git
 versions:
-- version: "3.11.6-1.0.0"
+- appVersion: "3.11.6"
+  operatorVersion: "1.0.0"
   git:
     source: kudo-cassandra-operator
     directory: operator
     tag: v3.11.6-1.0.0
-- version: "3.11.5-0.1.2"
+- appVersion: "3.11.5"
+  operatorVersion: "0.1.2"
   git:
     source: kudo-cassandra-operator
     directory: operator

--- a/operators/confluent-rest-proxy.yaml
+++ b/operators/confluent-rest-proxy.yaml
@@ -2,18 +2,18 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Confluent Rest Proxy
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "5.3.2"
-  operatorVersion: "0.3.0"
-  git:
-    source: operators
-    directory: repository/confluent-rest-proxy/operator
-    sha: 3919e5231c80911cd8ca352cfddba11685953fdb
-- appVersion: "5.3.2"
-  operatorVersion: "0.2.1"
-  git:
-    source: operators
-    directory: repository/confluent-rest-proxy/operator
-    sha: 8c34d63ff0c28bb9358cb81eea967c30bad4f56c
+  - appVersion: "5.3.2"
+    operatorVersion: "0.3.0"
+    git:
+      source: operators
+      directory: repository/confluent-rest-proxy/operator
+      sha: 3919e5231c80911cd8ca352cfddba11685953fdb
+  - appVersion: "5.3.2"
+    operatorVersion: "0.2.1"
+    git:
+      source: operators
+      directory: repository/confluent-rest-proxy/operator
+      sha: 8c34d63ff0c28bb9358cb81eea967c30bad4f56c

--- a/operators/confluent-rest-proxy.yaml
+++ b/operators/confluent-rest-proxy.yaml
@@ -1,16 +1,18 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Confluent Rest Proxy
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "5.3.2-0.3.0"
+- appVersion: "5.3.2"
+  operatorVersion: "0.3.0"
   git:
     source: operators
     directory: repository/confluent-rest-proxy/operator
     sha: 3919e5231c80911cd8ca352cfddba11685953fdb
-- version: "5.3.2-0.2.1"
+- appVersion: "5.3.2"
+  operatorVersion: "0.2.1"
   git:
     source: operators
     directory: repository/confluent-rest-proxy/operator

--- a/operators/confluent-schema-registry.yaml
+++ b/operators/confluent-schema-registry.yaml
@@ -1,16 +1,18 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Confluent Schema Registry
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "5.3.2-0.3.0"
+- appVersion: "5.3.2"
+  operatorVersion: "0.3.0"
   git:
     source: operators
     directory: repository/confluent-schema-registry/operator
     sha: 89a1fd281d41e68a22140b4f951397d427889812
-- version: "5.3.2-0.2.1"
+- appVersion: "5.3.2"
+  operatorVersion: "0.2.1"
   git:
     source: operators
     directory: repository/confluent-schema-registry/operator

--- a/operators/confluent-schema-registry.yaml
+++ b/operators/confluent-schema-registry.yaml
@@ -2,18 +2,18 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Confluent Schema Registry
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "5.3.2"
-  operatorVersion: "0.3.0"
-  git:
-    source: operators
-    directory: repository/confluent-schema-registry/operator
-    sha: 89a1fd281d41e68a22140b4f951397d427889812
-- appVersion: "5.3.2"
-  operatorVersion: "0.2.1"
-  git:
-    source: operators
-    directory: repository/confluent-schema-registry/operator
-    sha: 55c4e66f77a8a43798276cb43aa844e65c30d72e
+  - appVersion: "5.3.2"
+    operatorVersion: "0.3.0"
+    git:
+      source: operators
+      directory: repository/confluent-schema-registry/operator
+      sha: 89a1fd281d41e68a22140b4f951397d427889812
+  - appVersion: "5.3.2"
+    operatorVersion: "0.2.1"
+    git:
+      source: operators
+      directory: repository/confluent-schema-registry/operator
+      sha: 55c4e66f77a8a43798276cb43aa844e65c30d72e

--- a/operators/cowsay.yaml
+++ b/operators/cowsay.yaml
@@ -2,11 +2,11 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Cowsay
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/cowsay/operator
-    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4
+  - operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/cowsay/operator
+      sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/cowsay.yaml
+++ b/operators/cowsay.yaml
@@ -1,11 +1,11 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Cowsay
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "0.2.0"
+- operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/cowsay/operator

--- a/operators/elastic.yaml
+++ b/operators/elastic.yaml
@@ -2,12 +2,12 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Elasticsearch
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- operatorVersion: "7.0.0"
-  appVersion: "0.2.1"
-  git:
-    source: operators
-    directory: repository/elastic/operator
-    sha: 10c82d668a1a63af4eb887857bd0c40dc4881a99
+  - operatorVersion: "7.0.0"
+    appVersion: "0.2.1"
+    git:
+      source: operators
+      directory: repository/elastic/operator
+      sha: 10c82d668a1a63af4eb887857bd0c40dc4881a99

--- a/operators/elastic.yaml
+++ b/operators/elastic.yaml
@@ -1,11 +1,12 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Elasticsearch
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "7.0.0-0.2.1"
+- operatorVersion: "7.0.0"
+  appVersion: "0.2.1"
   git:
     source: operators
     directory: repository/elastic/operator

--- a/operators/first-operator.yaml
+++ b/operators/first-operator.yaml
@@ -1,11 +1,11 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: First Operator
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "0.2.0"
+- operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/first-operator/operator

--- a/operators/first-operator.yaml
+++ b/operators/first-operator.yaml
@@ -2,11 +2,11 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: First Operator
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/first-operator/operator
-    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4
+  - operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/first-operator/operator
+      sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/flink.yaml
+++ b/operators/flink.yaml
@@ -2,12 +2,12 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Flink
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "1.7.2"
-  operatorVersion: "0.2.1"
-  git:
-    source: operators
-    directory: repository/flink/operator
-    sha: 258f17b0a4971460b6a44bbfdfa58e5721486f3a
+  - appVersion: "1.7.2"
+    operatorVersion: "0.2.1"
+    git:
+      source: operators
+      directory: repository/flink/operator
+      sha: 258f17b0a4971460b6a44bbfdfa58e5721486f3a

--- a/operators/flink.yaml
+++ b/operators/flink.yaml
@@ -1,11 +1,12 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Flink
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "1.7.2-0.2.1"
+- appVersion: "1.7.2"
+  operatorVersion: "0.2.1"
   git:
     source: operators
     directory: repository/flink/operator

--- a/operators/kafka.yaml
+++ b/operators/kafka.yaml
@@ -2,30 +2,30 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Kafka
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "2.5.0"
-  operatorVersion: "1.3.2"
-  git:
-    source: operators
-    directory: repository/kafka/operator
-    sha: e2354fd0ec4cd23144bf5cc15dc613d45d650748
-- appVersion: "2.5.0"
-  operatorVersion: "1.3.1"
-  git:
-    source: operators
-    directory: repository/kafka/operator
-    sha: b95e9f9aa149592d402f50ee38148b380baf0602
-- appVersion: "2.5.0"
-  operatorVersion: "1.3.0"
-  git:
-    source: operators
-    directory: repository/kafka/operator
-    sha: 284b6b2aae0f7952a1cc22854483c479ef569e28
-- appVersion: "2.4.1"
-  operatorVersion: "1.2.1"
-  git:
-    source: operators
-    directory: repository/kafka/operator
-    sha: 92799adea05cbcee9d409cb6a0ae8359887634fa
+  - appVersion: "2.5.0"
+    operatorVersion: "1.3.2"
+    git:
+      source: operators
+      directory: repository/kafka/operator
+      sha: e2354fd0ec4cd23144bf5cc15dc613d45d650748
+  - appVersion: "2.5.0"
+    operatorVersion: "1.3.1"
+    git:
+      source: operators
+      directory: repository/kafka/operator
+      sha: b95e9f9aa149592d402f50ee38148b380baf0602
+  - appVersion: "2.5.0"
+    operatorVersion: "1.3.0"
+    git:
+      source: operators
+      directory: repository/kafka/operator
+      sha: 284b6b2aae0f7952a1cc22854483c479ef569e28
+  - appVersion: "2.4.1"
+    operatorVersion: "1.2.1"
+    git:
+      source: operators
+      directory: repository/kafka/operator
+      sha: 92799adea05cbcee9d409cb6a0ae8359887634fa

--- a/operators/kafka.yaml
+++ b/operators/kafka.yaml
@@ -1,26 +1,30 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Kafka
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "2.5.0-1.3.2"
+- appVersion: "2.5.0"
+  operatorVersion: "1.3.2"
   git:
     source: operators
     directory: repository/kafka/operator
     sha: e2354fd0ec4cd23144bf5cc15dc613d45d650748
-- version: "2.5.0-1.3.1"
+- appVersion: "2.5.0"
+  operatorVersion: "1.3.1"
   git:
     source: operators
     directory: repository/kafka/operator
     sha: b95e9f9aa149592d402f50ee38148b380baf0602
-- version: "2.5.0-1.3.0"
+- appVersion: "2.5.0"
+  operatorVersion: "1.3.0"
   git:
     source: operators
     directory: repository/kafka/operator
     sha: 284b6b2aae0f7952a1cc22854483c479ef569e28
-- version: "2.4.1-1.2.1"
+- appVersion: "2.4.1"
+  operatorVersion: "1.2.1"
   git:
     source: operators
     directory: repository/kafka/operator

--- a/operators/mysql.yaml
+++ b/operators/mysql.yaml
@@ -2,18 +2,18 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: MySQL
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "5.7"
-  operatorVersion: "0.3.0"
-  git:
-    source: operators
-    directory: repository/mysql/operator
-    sha: 8a2e41484513397be353bc5db10e8abc685bc975
-- appVersion: "5.7"
-  operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/mysql/operator
-    sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4
+  - appVersion: "5.7"
+    operatorVersion: "0.3.0"
+    git:
+      source: operators
+      directory: repository/mysql/operator
+      sha: 8a2e41484513397be353bc5db10e8abc685bc975
+  - appVersion: "5.7"
+    operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/mysql/operator
+      sha: 2b5b8ae28a83eb171d1c3094b92a1cc07e8c26f4

--- a/operators/mysql.yaml
+++ b/operators/mysql.yaml
@@ -1,16 +1,18 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: MySQL
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "5.7-0.3.0"
+- appVersion: "5.7"
+  operatorVersion: "0.3.0"
   git:
     source: operators
     directory: repository/mysql/operator
     sha: 8a2e41484513397be353bc5db10e8abc685bc975
-- version: "5.7-0.2.0"
+- appVersion: "5.7"
+  operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/mysql/operator

--- a/operators/rabbitmq.yaml
+++ b/operators/rabbitmq.yaml
@@ -2,12 +2,12 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: RabbitMQ
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "3.8.0"
-  operatorVersion: "0.1.0"
-  git:
-    source: operators
-    directory: repository/rabbitmq/operator
-    sha: a0a79c9615f139472fc23d4dca0d69dccdb7665c
+  - appVersion: "3.8.0"
+    operatorVersion: "0.1.0"
+    git:
+      source: operators
+      directory: repository/rabbitmq/operator
+      sha: a0a79c9615f139472fc23d4dca0d69dccdb7665c

--- a/operators/rabbitmq.yaml
+++ b/operators/rabbitmq.yaml
@@ -1,11 +1,12 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: RabbitMQ
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "3.8.0-0.1.0"
+- appVersion: "3.8.0"
+  operatorVersion: "0.1.0"
   git:
     source: operators
     directory: repository/rabbitmq/operator

--- a/operators/redis.yaml
+++ b/operators/redis.yaml
@@ -2,12 +2,12 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Redis
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "5.0.1"
-  operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/redis/operator
-    sha: 75f64ec77a5d000d801d70885490516a2db15cc6
+  - appVersion: "5.0.1"
+    operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/redis/operator
+      sha: 75f64ec77a5d000d801d70885490516a2db15cc6

--- a/operators/redis.yaml
+++ b/operators/redis.yaml
@@ -1,11 +1,12 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Redis
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "5.0.1-0.2.0"
+- appVersion: "5.0.1"
+  operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/redis/operator

--- a/operators/spark.yaml
+++ b/operators/spark.yaml
@@ -2,30 +2,30 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Spark
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "2.4.5"
-  operatorVersion: "1.0.1"
-  git:
-    source: operators
-    directory: repository/spark/operator
-    sha: d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3
-- appVersion: "2.4.5"
-  operatorVersion: "1.0.0"
-  git:
-    source: operators
-    directory: repository/spark/operator
-    sha: 1db171b3597ba8de91637df6e94edadea4d97d52
-- appVersion: "2.4.5"
-  operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/spark/operator
-    sha: a60cb076107199935bca5e58bae79b2aaade6fb9
-- appVersion: "2.4.4"
-  operatorVersion: "0.2.0"
-  git:
-    source: operators
-    directory: repository/spark/operator
-    sha: c39b33f09198e5db89b5366155b4e82c397c6269
+  - appVersion: "2.4.5"
+    operatorVersion: "1.0.1"
+    git:
+      source: operators
+      directory: repository/spark/operator
+      sha: d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3
+  - appVersion: "2.4.5"
+    operatorVersion: "1.0.0"
+    git:
+      source: operators
+      directory: repository/spark/operator
+      sha: 1db171b3597ba8de91637df6e94edadea4d97d52
+  - appVersion: "2.4.5"
+    operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/spark/operator
+      sha: a60cb076107199935bca5e58bae79b2aaade6fb9
+  - appVersion: "2.4.4"
+    operatorVersion: "0.2.0"
+    git:
+      source: operators
+      directory: repository/spark/operator
+      sha: c39b33f09198e5db89b5366155b4e82c397c6269

--- a/operators/spark.yaml
+++ b/operators/spark.yaml
@@ -1,26 +1,30 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Spark
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "2.4.5-1.0.1"
+- appVersion: "2.4.5"
+  operatorVersion: "1.0.1"
   git:
     source: operators
     directory: repository/spark/operator
     sha: d4cbfc347069d1e1f2795525a2c3e04e90b3d8a3
-- version: "2.4.5-1.0.0"
+- appVersion: "2.4.5"
+  operatorVersion: "1.0.0"
   git:
     source: operators
     directory: repository/spark/operator
     sha: 1db171b3597ba8de91637df6e94edadea4d97d52
-- version: "2.4.5-0.2.0"
+- appVersion: "2.4.5"
+  operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/spark/operator
     sha: a60cb076107199935bca5e58bae79b2aaade6fb9
-- version: "2.4.4-0.2.0"
+- appVersion: "2.4.4"
+  operatorVersion: "0.2.0"
   git:
     source: operators
     directory: repository/spark/operator

--- a/operators/zookeeper.yaml
+++ b/operators/zookeeper.yaml
@@ -1,11 +1,12 @@
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Zookeeper
-git-sources:
+gitSources:
 - name: operators
   url: https://github.com/kudobuilder/operators.git
 versions:
-- version: "3.4.14-0.3.0"
+- appVersion: "3.4.14"
+  operatorVersion: "0.3.0"
   git:
     source: operators
     directory: repository/zookeeper/operator

--- a/operators/zookeeper.yaml
+++ b/operators/zookeeper.yaml
@@ -2,12 +2,12 @@ apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: Zookeeper
 gitSources:
-- name: operators
-  url: https://github.com/kudobuilder/operators.git
+  - name: operators
+    url: https://github.com/kudobuilder/operators.git
 versions:
-- appVersion: "3.4.14"
-  operatorVersion: "0.3.0"
-  git:
-    source: operators
-    directory: repository/zookeeper/operator
-    sha: b9036ebc6291b99ff8c10b4947b6e5cf3a159399
+  - appVersion: "3.4.14"
+    operatorVersion: "0.3.0"
+    git:
+      source: operators
+      directory: repository/zookeeper/operator
+      sha: b9036ebc6291b99ff8c10b4947b6e5cf3a159399


### PR DESCRIPTION
Bumps `kitt` to v0.3.0, which uses `appVersion` and `operatorVersion` instead of `version`.