### PR TITLE
Bump 'kitt' to validate packages

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           docker run --rm \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
-            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
+            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
             update --repository /var/run/repo/index-test \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM HEAD~ | grep operators/ | sed 's/^/\/var\/run\//')

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Validate added/updated operators
         run: |
           docker run --rm \
-            -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
             docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
             validate \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,12 +42,21 @@ jobs:
       - name: Print added or modified files (debug)
         run: git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }}
 
+      - name: Validate added/updated operators
+        run: |
+          docker run --rm \
+            -v $GITHUB_WORKSPACE/repo:/var/run/repo \
+            -v $GITHUB_WORKSPACE/operators:/var/run/operators \
+            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
+            validate \
+              $(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} | grep operators/ | sed 's/^/\/var\/run\//')
+
       - name: Synchronize added/updated operators with temporary repository
         run: |
           docker run --rm \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
-            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.3.0 \
+            docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
             update --repository /var/run/repo/index-test \
               --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
               $(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} | grep operators/ | sed 's/^/\/var\/run\//')

--- a/operators/elastic.yaml
+++ b/operators/elastic.yaml
@@ -5,8 +5,8 @@ gitSources:
   - name: operators
     url: https://github.com/kudobuilder/operators.git
 versions:
-  - operatorVersion: "7.0.0"
-    appVersion: "0.2.1"
+  - operatorVersion: "0.2.1"
+    appVersion: "7.0.0"
     git:
       source: operators
       directory: repository/elastic/operator

--- a/operators/rabbitmq.yaml
+++ b/operators/rabbitmq.yaml
@@ -6,8 +6,8 @@ gitSources:
     url: https://github.com/kudobuilder/operators.git
 versions:
   - appVersion: "3.8.0"
-    operatorVersion: "0.1.0"
+    operatorVersion: "0.1.1"
     git:
       source: operators
       directory: repository/rabbitmq/operator
-      sha: a0a79c9615f139472fc23d4dca0d69dccdb7665c
+      sha: 9c98559618ad494daaa16153353e4edd0378d1b4

--- a/operators/zookeeper.yaml
+++ b/operators/zookeeper.yaml
@@ -6,8 +6,8 @@ gitSources:
     url: https://github.com/kudobuilder/operators.git
 versions:
   - appVersion: "3.4.14"
-    operatorVersion: "0.3.0"
+    operatorVersion: "0.3.1"
     git:
       source: operators
       directory: repository/zookeeper/operator
-      sha: b9036ebc6291b99ff8c10b4947b6e5cf3a159399
+      sha: 9c98559618ad494daaa16153353e4edd0378d1b4


### PR DESCRIPTION
Package references have to pass validation to get added to the index.
`rabbitmq` and `zookeeper` had validation errors and have been bumped to versions that pass validation.