### PR TITLE
Use a production repository

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           docker run --rm --volumes-from gcloud-cli \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             google/cloud-sdk:slim \
-            gsutil -m cp -r gs://kudo-repo/index-test /var/run/repo
+            gsutil -m cp -r gs://kudo-repository/v1 /var/run/repo
 
       - name: Authenticate with Github Packages
         run: docker login docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
@@ -48,8 +48,8 @@ jobs:
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
             docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
-            update --repository /var/run/repo/index-test \
-              --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
+            update --repository /var/run/repo/v1 \
+              --repository_url https://kudo-repository.storage.googleapis.com/v1/ \
               $(git diff --name-only --diff-filter=AM HEAD~ | grep operators/ | sed 's/^/\/var\/run\//')
 
       # We use 'rsync -c' to sync based on checksums and not mtime.
@@ -60,4 +60,4 @@ jobs:
           docker run --rm --volumes-from gcloud-cli \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             google/cloud-sdk:slim \
-            gsutil -m rsync -c /var/run/repo/index-test gs://kudo-repo/index-test
+            gsutil -m rsync -c /var/run/repo/v1 gs://kudo-repository/v1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           docker run --rm --volumes-from gcloud-cli \
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             google/cloud-sdk:slim \
-            gsutil -m cp -r gs://kudo-repo/index-test /var/run/repo
+            gsutil -m cp -r gs://kudo-repository/v1 /var/run/repo
 
       - name: Authenticate with Github Packages
         run: docker login docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
@@ -56,6 +56,6 @@ jobs:
             -v $GITHUB_WORKSPACE/repo:/var/run/repo \
             -v $GITHUB_WORKSPACE/operators:/var/run/operators \
             docker.pkg.github.com/kudobuilder/kitt/kitt:v0.4.0 \
-            update --repository /var/run/repo/index-test \
-              --repository_url https://kudo-repo.storage.googleapis.com/index-test/ \
+            update --repository /var/run/repo/v1 \
+              --repository_url https://kudo-repository.storage.googleapis.com/v1/ \
               $(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} | grep operators/ | sed 's/^/\/var\/run\//')

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # KUDO Operators Index
 
-*Alpha quality, this is still being tested!*
-
 Index of the community operators for KUDO.
 
 Each item in `operators` references one or more versions of an operator package. The community repository is build from the referenced packages. There's a one-to-one relationship between the referenced items in the index and the packages in the community repository.


### PR DESCRIPTION
`kudo-repository/v1` is used as storage bucket for the managed repository.